### PR TITLE
Fix typo in license name

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "walkmesdk"
   ],
   "author": "WalkMe",
-  "license": "Commerical",
+  "license": "Commercial",
   "homepage": "https://walkme.com",
   "description": "Simple SDK for developers to manage and maximize conversions of all in-app promotions.",
   "repository": {


### PR DESCRIPTION
Hey team, we're using automated license checks in our main codebase and, well, I found this tiny typo. Here is a fix 🎉 