### PR TITLE
add EventEmitter method

### DIFF
--- a/android/src/main/java/com/walkme/RNWalkMeSdkModule.java
+++ b/android/src/main/java/com/walkme/RNWalkMeSdkModule.java
@@ -288,5 +288,15 @@ public class RNWalkMeSdkModule extends ReactContextBaseJavaModule implements ABB
 
     sendEvent(this.getReactApplicationContext(), wmCampaignInfoEventWillShow, params);
   }
+    
+  @ReactMethod
+  public void addListener(String eventName) {
+      // Keep: Required for RN built-in Event Emitter Calls.
+  }
+
+  @ReactMethod
+  public void removeListeners(Integer count) {
+        // Keep: Required for RN built-in Event Emitter Calls.
+  }
 
 }


### PR DESCRIPTION
to prevent this warning in the metro
````
 WARN  `new NativeEventEmitter()` was called with a non-null argument without the required `addListener` method.

 WARN  `new NativeEventEmitter()` was called with a non-null argument without the required `removeListeners` method.
````

![image](https://github.com/user-attachments/assets/bd91f385-1be2-4c48-8ad8-da94a17f9415)
